### PR TITLE
Fix sponsor email redirection

### DIFF
--- a/src/components/Sponsor.js
+++ b/src/components/Sponsor.js
@@ -6,7 +6,7 @@ import bg from "../assets/purple-bg.webp";
 import Reveal from "../util/Reveal";
 
 const handleClick = () => {
-  window.location.href = "mailto:unswai.soc.industry@gmail.com";
+  window.location.href = "mailto:partnerships@unswaisoc.com";
 };
 
 const Sponsor = () => {


### PR DESCRIPTION
Update the "Sponsor Us" link to redirect to the correct email address.

* Change the `handleClick` function in `src/components/Sponsor.js` to set `window.location.href` to `mailto:partnerships@unswaisoc.com` instead of `mailto:unswai.soc.industry@gmail.com`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AISoc-UNSW/Ai-Society-Website/pull/26?shareId=2e39b2b1-18b4-436e-95fd-be6744098cbf).